### PR TITLE
add support for slick 3.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /project/*-shim.sbt
 /project/project/
 /project/target/
+/.idea
 /target/

--- a/README.md
+++ b/README.md
@@ -7,12 +7,18 @@ slick-codegen compile hook for sbt
 ```scala
 // plugins.sbt
 
-addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % "1.1.1")
+addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % "1.2.0")
 
 // Database driver
 // For example, when you are using PostgreSQL
 libraryDependencies += "org.postgresql" % "postgresql" % "9.4-1201-jdbc41"
 ```
+Table capability
+
+|Slick version|Plugin version|
+|-------------|--------------|
+|3.1.x|1.2.0|
+|3.0.x|1.1.1|
 
 ## Configuration
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,11 @@ name := """sbt-slick-codegen"""
 
 organization := "com.github.tototoshi"
 
-version := "1.1.1"
+version := "1.2.0"
 
-scalaVersion := "2.10.5"
+scalaVersion := "2.10.6"
 
-val slickVersion = "3.0.2"
+val slickVersion = "3.1.0"
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % slickVersion,


### PR DESCRIPTION
If I add the new verison of slick dependences to the plugins.sbt,then it will occur an exceptioon:
```
[assetsServer] $ last assetsServer/*:slickCodegen
java.lang.NoSuchMethodError: slick.driver.JdbcProfile$API.Database()Lslick/backend/DatabaseComponent$DatabaseFactoryDef;
	at com.github.tototoshi.sbt.slick.CodegenPlugin$.com$github$tototoshi$sbt$slick$CodegenPlugin$$gen(CodegenPlugin.scala:64)
	at com.github.tototoshi.sbt.slick.CodegenPlugin$$anonfun$slickCodegenSettings$12.apply(CodegenPlugin.scala:118)
	at com.github.tototoshi.sbt.slick.CodegenPlugin$$anonfun$slickCodegenSettings$12.apply(CodegenPlugin.scala:106)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:235)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```
