### PR TITLE
Function correctly with third-party Slick drivers

### DIFF
--- a/src/main/scala/com/github/tototoshi/sbt/slick/CodegenPlugin.scala
+++ b/src/main/scala/com/github/tototoshi/sbt/slick/CodegenPlugin.scala
@@ -77,10 +77,18 @@ object CodegenPlugin extends sbt.Plugin {
 
     val tables = driver.defaultTables.map(ts => ts.filterNot(t => excluded contains t.name.name))
 
+    val driverClassName = driver.getClass.getName
+    val profile = {
+      // if it's a singleton object, then just reference it directly
+      if (driverClassName.endsWith("$")) driverClassName.stripSuffix("$")
+      // if it's an instance of a regular class, we don't know constructor args; try the no-arguments constructor and hope for the best
+      else s"new $driverClassName()"
+    }
+
     val dbio = for {
       m <- driver.createModel(Some(tables))
     } yield generator(m).writeToFile(
-      profile = "slick.driver." + driver.toString,
+      profile = profile,
       folder = outputDir,
       pkg = pkg,
       container = container,


### PR DESCRIPTION
The old code tried to work around the bizarre toString method of
BasicDriver:

```
val cl = getClass.getName
if(cl.startsWith("slick.driver.") && cl.endsWith("$"))
  cl.substring(13, cl.length-1)
else super.toString
```

by re-adding the "slick.driver." prefix.

With third-party drivers, this would produce code like this:

```
object Tables extends {
  val profile = slick.driver.com.example.ThirdPartyDriver$@deadbeef
} with Tables
```

This commit changes the relevant code to instead
1. replicate the part of BasicDriver.toString that deals with singleton
   objects (strip the '$'),
2. forget the rest (stripping "slick.driver."), and
3. don't re-add "slick.driver." after the fact.

(Non-singleton-object drivers aren't supported, and never were.)

After this change, generated code for third-party drivers should look
like this:

```
object Tables extends {
  val profile = com.example.ThirdPartyDriver
} with Tables
```
