### PR TITLE
Allow multiple file generation with the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ slickCodegenExcludedTables in Compile := Seq("schema_version")
 
 //optional
 slickCodegenOutputDir := (sourceManaged in Compile).value
+
+//optional. Generate one Scala file per table.
+slickCodegenOutputToMultipleFiles := false
 ```
 
 ## Example

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scalariform.formatter.preferences._
 import scala.collection.JavaConverters._
 import java.lang.management.ManagementFactory
 
-enablePlugins(ScriptedPlugin)
+enablePlugins(SbtPlugin)
 
 scalariformPreferences := scalariformPreferences.value
   .setPreference(AlignSingleLineCaseStatements, true)

--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,8 @@ version := "1.4.1-SNAPSHOT"
 val slickVersion = SettingKey[String]("slickVersion")
 
 slickVersion := {
-  if((sbtVersion in pluginCrossBuild).value.startsWith("1.")) {
-    "3.3.2"
+  if ((pluginCrossBuild / sbtVersion).value.startsWith("1.")) {
+    "3.3.3"
   } else {
     "3.1.0"
   }
@@ -42,7 +42,7 @@ publishTo := {
   else Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 
 pomExtra :=
   <url>https://github.com/tototoshi/sbt-slick-codegen</url>
@@ -65,10 +65,9 @@ pomExtra :=
     </developer>
   </developers>
 
-
 scriptedBufferLog := false
-scriptedLaunchOpts ++= ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toList.filter(
-  a => Seq("-Xmx", "-Xms", "-XX", "-Dsbt.log.noformat").exists(a.startsWith)
+scriptedLaunchOpts ++= ManagementFactory.getRuntimeMXBean.getInputArguments.asScala.toList.filter(a =>
+  Seq("-Xmx", "-Xms", "-XX", "-Dsbt.log.noformat").exists(a.startsWith)
 )
 scriptedLaunchOpts ++= Seq(
   "-Dplugin.version=" + version.value,

--- a/src/main/scala/com/github/tototoshi/sbt/slick/CodegenPlugin.scala
+++ b/src/main/scala/com/github/tototoshi/sbt/slick/CodegenPlugin.scala
@@ -3,7 +3,7 @@ package com.github.tototoshi.sbt.slick
 import sbt._
 import Keys._
 import slick.codegen.SourceCodeGenerator
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 import slick.{ model => m }
 
 import scala.concurrent.Await
@@ -49,7 +49,9 @@ object CodegenPlugin extends sbt.AutoPlugin {
       settingKey[Seq[String]]("Tables that should be excluded")
 
     lazy val slickCodegenIncludedTables: SettingKey[Seq[String]] =
-      settingKey[Seq[String]]("Tables that should be included. If this list is not nil, only the included tables minus excluded will be taken.")
+      settingKey[Seq[String]](
+        "Tables that should be included. If this list is not nil, only the included tables minus excluded will be taken."
+      )
 
     lazy val defaultSourceCodeGenerator: m.Model => SourceCodeGenerator = (model: m.Model) =>
       new SourceCodeGenerator(model)
@@ -73,7 +75,8 @@ object CodegenPlugin extends sbt.AutoPlugin {
     container: String,
     excluded: Seq[String],
     included: Seq[String],
-    s: TaskStreams): File = {
+    s: TaskStreams
+  ): File = {
 
     val database = driver.api.Database.forURL(url = url, driver = jdbcDriver, user = user, password = password)
 
@@ -116,14 +119,14 @@ object CodegenPlugin extends sbt.AutoPlugin {
   }
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    slickCodegenDriver := slick.driver.PostgresDriver,
+    slickCodegenDriver := slick.jdbc.PostgresProfile,
     slickCodegenJdbcDriver := "org.postgresql.Driver",
     slickCodegenDatabaseUrl := "Database url is not set",
     slickCodegenDatabaseUser := "Database user is not set",
     slickCodegenDatabasePassword := "Database password is not set",
     slickCodegenOutputPackage := "com.example",
     slickCodegenOutputFile := "Tables.scala",
-    slickCodegenOutputDir := (sourceManaged in Compile).value,
+    slickCodegenOutputDir := (Compile / sourceManaged).value,
     slickCodegenOutputContainer := "Tables",
     slickCodegenExcludedTables := Seq(),
     slickCodegenIncludedTables := Seq(),
@@ -140,21 +143,23 @@ object CodegenPlugin extends sbt.AutoPlugin {
       }
       val outPkg = (slickCodegenOutputPackage).value
       val outFile = (slickCodegenOutputFile).value
-      Seq(gen(
-        (slickCodegenCodeGenerator).value,
-        (slickCodegenDriver).value,
-        (slickCodegenJdbcDriver).value,
-        (slickCodegenDatabaseUrl).value,
-        (slickCodegenDatabaseUser).value,
-        (slickCodegenDatabasePassword).value,
-        outDir,
-        outPkg,
-        outFile,
-        slickCodegenOutputContainer.value,
-        slickCodegenExcludedTables.value,
-        slickCodegenIncludedTables.value,
-        streams.value
-      ))
+      Seq(
+        gen(
+          (slickCodegenCodeGenerator).value,
+          (slickCodegenDriver).value,
+          (slickCodegenJdbcDriver).value,
+          (slickCodegenDatabaseUrl).value,
+          (slickCodegenDatabaseUser).value,
+          (slickCodegenDatabasePassword).value,
+          outDir,
+          outPkg,
+          outFile,
+          slickCodegenOutputContainer.value,
+          slickCodegenExcludedTables.value,
+          slickCodegenIncludedTables.value,
+          streams.value
+        )
+      )
     }
   )
 

--- a/src/sbt-test/test/basic/build.sbt
+++ b/src/sbt-test/test/basic/build.sbt
@@ -11,10 +11,12 @@ libraryDependencies += "com.typesafe.slick" %% "slick" % System.getProperty("sli
 
 enablePlugins(CodegenPlugin)
 
-sourceGenerators in Compile += slickCodegen
+Compile / sourceGenerators += slickCodegen
 
-slickCodegenDatabaseUrl := "jdbc:postgresql://postgres/example"
+slickCodegenDatabaseUrl := "jdbc:postgresql://localhost/example"
 
 slickCodegenDatabaseUser := "test"
 
 slickCodegenDatabasePassword := "test"
+
+slickCodegenOutputToMultipleFiles := true

--- a/src/sbt-test/test/basic/build.sbt
+++ b/src/sbt-test/test/basic/build.sbt
@@ -1,11 +1,6 @@
-crossScalaVersions := Seq("2.11.12")
+crossScalaVersions := Seq("2.12.15", "2.13.8")
 
-crossScalaVersions ++= {
-  if (sbtVersion.value startsWith "1.")
-    Seq("2.12.8", "2.13.0")
-  else
-    Nil
-}
+Global / onChangedBuildSource := ReloadOnSourceChanges
 
 libraryDependencies += "com.typesafe.slick" %% "slick" % System.getProperty("slick.version")
 
@@ -13,7 +8,7 @@ enablePlugins(CodegenPlugin)
 
 Compile / sourceGenerators += slickCodegen
 
-slickCodegenDatabaseUrl := "jdbc:postgresql://localhost/example"
+slickCodegenDatabaseUrl := "jdbc:postgresql://postgres/example"
 
 slickCodegenDatabaseUser := "test"
 

--- a/src/sbt-test/test/basic/project/build.properties
+++ b/src/sbt-test/test/basic/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/src/sbt-test/test/basic/project/plugins.sbt
+++ b/src/sbt-test/test/basic/project/plugins.sbt
@@ -1,4 +1,8 @@
-addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % System.getProperty("plugin.version"))
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
 
 libraryDependencies += "org.postgresql" % "postgresql" % "9.4-1201-jdbc41"
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.25"

--- a/src/sbt-test/test/basic/test
+++ b/src/sbt-test/test/basic/test
@@ -1,5 +1,9 @@
-$ exec psql -c 'create table users (id bigint primary key, name varchar(256));' -U test -h postgres example
+$ exec psql -c 'create table if not exists users (id bigint primary key, name varchar(256));' -U test -h localhost example
+> slickCodegen
+$ pause
 > + compile
 
 $ exists target/scala-2.11/src_managed/main/com/example/Tables.scala
 $ exists target/scala-2.11/classes/com/example/Tables.class
+$ exists target/scala-2.11/src_managed/main/com/example/Users.scala
+$ exists target/scala-2.11/classes/com/example/Users.class

--- a/src/sbt-test/test/basic/test
+++ b/src/sbt-test/test/basic/test
@@ -1,9 +1,5 @@
-$ exec psql -c 'create table if not exists users (id bigint primary key, name varchar(256));' -U test -h localhost example
-> slickCodegen
-$ pause
+$ exec psql -c 'create table if not exists users (id bigint primary key, name varchar(256));' -U test -h postgres example
 > + compile
 
-$ exists target/scala-2.11/src_managed/main/com/example/Tables.scala
-$ exists target/scala-2.11/classes/com/example/Tables.class
-$ exists target/scala-2.11/src_managed/main/com/example/Users.scala
-$ exists target/scala-2.11/classes/com/example/Users.class
+$ exists target/scala-2.13/src_managed/main/com/example/Tables.scala
+$ exists target/scala-2.13/src_managed/main/com/example/UsersTable.scala


### PR DESCRIPTION
This PR provides several improvements:

- Bumps to latest slick version (3.3.3). That means scala 2.11 is no longer supported.
- Fixes some deprecation warnings with Slick and SBT
- Allows multiple file generation inspired by https://github.com/tototoshi/sbt-slick-codegen/pull/29 

This PR closes https://github.com/tototoshi/sbt-slick-codegen/pull/29 